### PR TITLE
Implementation of pod delete + capacity(disabled)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ docker:
 	@echo "Docker Build..."
 	$Q docker build -t $(DOCKER_IMAGE) .
 
-clean: clean-build
+clean:
 	@echo "Clean..."
 	$Q rm -rf bin
 

--- a/providers/vic/pod_creator.go
+++ b/providers/vic/pod_creator.go
@@ -189,6 +189,8 @@ func (v *VicPodCreator) createPod(op trace.Operation, pod *v1.Pod, start bool) (
 		return "", err
 	}
 
+	op.Infof("Created Pod: %s, Handle: %s, ID: %s", pod.Name, h, id)
+
 	return id, nil
 }
 

--- a/providers/vic/pod_deleter.go
+++ b/providers/vic/pod_deleter.go
@@ -1,0 +1,144 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vic
+
+import (
+	"fmt"
+
+	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/cache"
+	vicpod "github.com/virtual-kubelet/virtual-kubelet/providers/vic/pod"
+	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
+
+	"github.com/vmware/vic/lib/apiservers/engine/errors"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/pkg/retry"
+	"github.com/vmware/vic/pkg/trace"
+
+	"k8s.io/api/core/v1"
+)
+
+type PodDeleter interface {
+	DeletePod(op trace.Operation, pod *v1.Pod, start bool) error
+}
+
+type VicPodDeleter struct {
+	client         *client.PortLayer
+	imageStore     proxy.ImageStore
+	isolationProxy proxy.IsolationProxy
+	podCache       cache.PodCache
+	personaAddr    string
+	portlayerAddr  string
+}
+
+type DeleteResponse struct {
+	Id       string `json:"Id"`
+	Warnings string `json:"Warnings"`
+}
+
+func NewPodDeleter(client *client.PortLayer, isolationProxy proxy.IsolationProxy, podCache cache.PodCache, personaAddr string, portlayerAddr string) *VicPodDeleter {
+	return &VicPodDeleter{
+		client:         client,
+		podCache:       podCache,
+		personaAddr:    personaAddr,
+		portlayerAddr:  portlayerAddr,
+		isolationProxy: isolationProxy,
+	}
+}
+
+func (v *VicPodDeleter) DeletePod(op trace.Operation, pod *v1.Pod) error {
+	defer trace.End(trace.Begin(pod.Name, op))
+
+	// Get pod from cache
+	vp, err := v.podCache.Get(op, "", pod.Name)
+
+	if err != nil {
+		return err
+	}
+
+	// Stop pod if not already stopped
+
+	// Transform kube container config to docker create config
+	err = v.deletePod(op, vp, true)
+	if err != nil {
+		op.Errorf("PodDeleter failed to delete pod: %s", err.Error())
+		return err
+	}
+
+	op.Infof("PodDeleter deleting from cache, name: %s, ID: %s", pod.Name, vp.ID)
+	v.podCache.Delete(op, pod.Name)
+
+	return nil
+}
+
+//  deletes a pod using the VIC portlayer.
+//
+//	returns id of pod as a string and error
+func (v *VicPodDeleter) deletePod(op trace.Operation, vp *vicpod.VicPod, force bool) error {
+	defer trace.End(trace.Begin("", op))
+
+	id := vp.ID
+	name := vp.Pod.Name
+	running := false
+
+	stopper := NewPodStopper(v.client, v.isolationProxy)
+	// Use the force and stop the container first
+	if force {
+		if err := stopper.Stop(op, id, name); err != nil {
+			return err
+		}
+	} else {
+		state, err := v.isolationProxy.State(op, id, name)
+		if err != nil {
+			return err
+		}
+
+		switch state {
+		case "Error":
+			// force stop if container state is error to make sure container is deletable later
+			stopper.Stop(op, id, name)
+		case "Starting":
+			// if we are starting let the user know they must use the force
+			return fmt.Errorf("The container is starting.  To remove use -f")
+		case "Running":
+			running = true
+		}
+
+		handle, err := v.isolationProxy.Handle(op, id, name)
+		if err != nil {
+			return err
+		}
+
+		// Unbind the container to the scope
+		_, ep, err := v.isolationProxy.UnbindScope(op, handle, name)
+		if err != nil {
+			return err
+		}
+		op.Infof("Scope Unbind returned endpoints %# +v", ep)
+	}
+
+	// Retry remove operation if container is not in running state.  If in running state, we only try
+	// once to prevent retries from degrading performance.
+	if !running {
+		operation := func() error {
+			return v.isolationProxy.Remove(op, id, true)
+		}
+		op.Infof("Delete Pod, ID: %s, running: %v", vp.ID, running)
+		return retry.Do(operation, errors.IsConflictError)
+	}
+
+	err := v.isolationProxy.Remove(op, id, true)
+	op.Infof("Delete Pod, ID: %s, running: %v err: %v", vp.ID, running, err)
+	return err
+}

--- a/providers/vic/pod_stopper.go
+++ b/providers/vic/pod_stopper.go
@@ -1,0 +1,80 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vic
+
+import (
+	"time"
+
+	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
+	"github.com/vmware/vic/lib/apiservers/engine/errors"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/pkg/retry"
+	"github.com/vmware/vic/pkg/trace"
+)
+
+type PodStopper interface {
+	Start(op trace.Operation, id, name string) error
+}
+
+type VicPodStopper struct {
+	client         *client.PortLayer
+	isolationProxy proxy.IsolationProxy
+}
+
+func NewPodStopper(client *client.PortLayer, isolationProxy proxy.IsolationProxy) *VicPodStopper {
+	return &VicPodStopper{
+		client:         client,
+		isolationProxy: isolationProxy,
+	}
+}
+
+func (v *VicPodStopper) Stop(op trace.Operation, id, name string) error {
+	operation := func() error {
+		return v.stop(op, id, name)
+	}
+
+	config := retry.NewBackoffConfig()
+	config.MaxElapsedTime = 10 * time.Minute
+	if err := retry.DoWithConfig(operation, errors.IsConflictError, config); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *VicPodStopper) stop(op trace.Operation, id, name string) error {
+	defer trace.End(trace.Begin(name, op))
+
+	h, err := v.isolationProxy.Handle(op, id, name)
+	if err != nil {
+		return err
+	}
+
+	// Unbind the container to the scope
+	h, ep, err := v.isolationProxy.UnbindScope(op, h, name)
+	if err != nil {
+		return err
+	}
+
+	op.Infof("Scope Unbind returned endpoints %# +v", ep)
+
+	h, err = v.isolationProxy.SetState(op, h, name, "STOPPED")
+	if err != nil {
+		return err
+	}
+
+	err = v.isolationProxy.CommitHandle(op, h, id, -1)
+	op.Infof("Commit handler returned %v", err)
+	return err
+}

--- a/providers/vic/utils/units.go
+++ b/providers/vic/utils/units.go
@@ -1,0 +1,182 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	BYTE = 1.0 << (10 * iota)
+	KILOBYTE
+	MEGABYTE
+	GIGABYTE
+	TERABYTE
+	PETABYTE
+)
+
+const (
+	KILOBYTESUFFIX = "Ki"
+	MEGABYTESUFFIX = "Mi"
+	GIGABYTESUFFIX = "Gi"
+	TERABYTESUFFIX = "Ti"
+	PETABYTESUFFIX = "Pi"
+)
+
+const (
+	ONE  = 1.0
+	KILO = 1000.0
+	MEGA = KILO * KILO
+	GIGA = MEGA * KILO
+	TERA = GIGA * KILO
+	PETA = TERA * KILO
+)
+
+const (
+	KILOSUFFIX = "K"
+	MEGASUFFIX = "M"
+	GIGASUFFIX = "G"
+	TERASUFFIX = "T"
+	PETASUFFIX = "P"
+)
+
+const (
+	MEMORYCUTOVER    = 100
+	FREQUENCYCUTOVER = 10
+)
+
+func MemsizeToBytesize(size int64, unit string) int64 {
+	u := strings.ToLower(unit)
+	var sizeInBytes int64
+	switch u {
+	case "b":
+		sizeInBytes = size
+		break
+	case "k":
+	case "kb":
+		sizeInBytes = size * KILOBYTE
+		break
+	case "m":
+	case "mb":
+		sizeInBytes = size * MEGABYTE
+		break
+	case "g":
+	case "gb":
+		sizeInBytes = size * GIGABYTE
+		break
+	case "t":
+	case "tb":
+		sizeInBytes = size * TERABYTE
+		break
+	case "p":
+	case "pb":
+		sizeInBytes = size * PETABYTE
+		break
+	default:
+		return 0
+	}
+
+	return sizeInBytes
+}
+
+func MemsizeToDecimalString(size int64, unit string) string {
+	sizeInBytes := MemsizeToBytesize(size, unit)
+
+	var res string
+	if sizeInBytes >= PETA*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/PETA, PETASUFFIX)
+	} else if sizeInBytes >= TERA*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/TERA, TERASUFFIX)
+	} else if sizeInBytes >= GIGA*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/GIGA, GIGASUFFIX)
+	} else if sizeInBytes >= MEGA*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/MEGA, MEGASUFFIX)
+	} else if sizeInBytes >= KILO*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/KILO, KILOSUFFIX)
+	} else {
+		res = fmt.Sprintf("%d", sizeInBytes)
+	}
+
+	return res
+}
+
+func MemsizeToBinaryString(size int64, unit string) string {
+	sizeInBytes := MemsizeToBytesize(size, unit)
+
+	var res string
+	if sizeInBytes >= PETABYTE*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/PETABYTE, PETABYTESUFFIX)
+	} else if sizeInBytes >= TERABYTE*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/TERABYTE, TERABYTESUFFIX)
+	} else if sizeInBytes >= GIGABYTE*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/GIGABYTE, GIGABYTESUFFIX)
+	} else if sizeInBytes >= MEGABYTE*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/MEGABYTE, MEGABYTESUFFIX)
+	} else if sizeInBytes >= KILOBYTE*MEMORYCUTOVER {
+		res = fmt.Sprintf("%d%s", sizeInBytes/KILOBYTE, KILOBYTESUFFIX)
+	} else {
+		res = fmt.Sprintf("%d", sizeInBytes)
+	}
+
+	return res
+}
+
+func FrequencyToHertzFrequency(size int64, unit string) int64 {
+	u := strings.ToLower(unit)
+	var sizeInBytes int64
+	switch u {
+	case "k":
+	case "khz":
+		sizeInBytes = size * KILO
+		break
+	case "m":
+	case "mhz":
+		sizeInBytes = size * MEGA
+		break
+	case "g":
+	case "ghz":
+		sizeInBytes = size * GIGA
+		break
+	default:
+		return 0
+	}
+
+	return sizeInBytes
+}
+
+func CpuFrequencyToString(size int64, unit string) string {
+	var res string
+
+	hertz := FrequencyToHertzFrequency(size, unit)
+	if hertz >= GIGA*10 {
+		res = fmt.Sprintf("%d%s", hertz/GIGA, GIGASUFFIX)
+	} else if hertz >= MEGA*FREQUENCYCUTOVER {
+		res = fmt.Sprintf("%d%s", hertz/MEGA, MEGASUFFIX)
+	} else if hertz >= KILO*FREQUENCYCUTOVER {
+		res = fmt.Sprintf("%d%s", hertz/KILO, KILOSUFFIX)
+	} else {
+		res = fmt.Sprintf("%d", hertz)
+	}
+
+	return res
+}
+
+func CpuFrequencyToCores(size int64, unit string) int64 {
+	hertz := FrequencyToHertzFrequency(size, unit)
+	// Assume 1G per Core
+	cores := hertz / GIGA
+	return cores
+}

--- a/providers/vic/utils/units_test.go
+++ b/providers/vic/utils/units_test.go
@@ -1,0 +1,67 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+    "github.com/stretchr/testify/require"
+	"strings"
+)
+
+func TestMemoryConversion(t *testing.T) {
+	memSize := MemsizeToBinaryString(2, "Gb")
+	require.True(t, memSize == "2048Mi")
+
+	memSize = MemsizeToDecimalString(2, "Gb")
+	require.True(t, memSize == "2147M")
+
+	memSize = MemsizeToBinaryString(2048, "Mb")
+	require.True(t, memSize == "2048Mi")
+
+	memSize = MemsizeToDecimalString(2048, "Mb")
+	require.True(t, memSize == "2147M")
+
+	memSize = MemsizeToBinaryString(2048*1024, "Kb")
+	require.True(t, memSize == "2048Mi")
+
+	memSize = MemsizeToDecimalString(2048*1024, "Kb")
+	require.True(t, memSize == "2147M")
+
+	memSize = MemsizeToBinaryString(MEMORYCUTOVER, "Gb")
+	require.True(t, memSize == "100Gi")
+
+	memSize = MemsizeToBinaryString(MEMORYCUTOVER-1, "Gb")
+	strings.HasSuffix(memSize, "Mi")
+	require.True(t, strings.HasSuffix(memSize, "Mi"))
+
+	memSize = MemsizeToBinaryString((MEMORYCUTOVER-1)*1024, "Mb")
+	require.True(t, strings.HasSuffix(memSize, "Mi"))
+
+	memSize = MemsizeToDecimalString(MEMORYCUTOVER*1000000000, "b")
+	require.True(t, memSize == "100G")
+
+	memSize = MemsizeToDecimalString((MEMORYCUTOVER-1)*1000000000, "b")
+	require.True(t, strings.HasSuffix(memSize, "M"))
+}
+
+func TestFrequencyConversion(t *testing.T) {
+	feq := CpuFrequencyToString(FREQUENCYCUTOVER, "Ghz")
+	require.True(t, feq == "10G")
+	feq = CpuFrequencyToString(FREQUENCYCUTOVER-1, "Ghz")
+	require.True(t, feq == "9000M")
+	feq = CpuFrequencyToString((FREQUENCYCUTOVER-1)*1000, "Mhz")
+	require.True(t, feq == "9000M")
+}


### PR DESCRIPTION
The new implementation of capacity is disable as it seems to create some instability when the node is registered (registration succeeds but no pod is scheduled, including the kubeproxy).