### PR TITLE
Implementation of POD Stopper and Deleter unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ docker:
 	@echo "Docker Build..."
 	$Q docker build -t $(DOCKER_IMAGE) .
 
-clean:
+clean: clean-build
 	@echo "Clean..."
 	$Q rm -rf bin
 

--- a/providers/vic/operations/common_test.go
+++ b/providers/vic/operations/common_test.go
@@ -1,0 +1,275 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"context"
+	"testing"
+
+	vicpod "github.com/virtual-kubelet/virtual-kubelet/providers/vic/pod"
+
+	"github.com/vmware/vic/lib/metadata"
+	"github.com/vmware/vic/pkg/trace"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"fmt"
+	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/cache"
+	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
+	proxymocks "github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy/mocks"
+)
+
+var (
+	pod              v1.Pod
+	imgConfig        metadata.ImageConfig
+	busyboxIsoConfig proxy.IsolationContainerConfig
+	alpineIsoConfig  proxy.IsolationContainerConfig
+	vicPod           vicpod.VicPod
+)
+
+const (
+	podID     = "123"
+	podName   = "busybox-sleep"
+	podHandle = "fakehandle"
+
+	fakeEP = "fake-endpoint"
+)
+
+func createMocks(t *testing.T) (*proxymocks.ImageStore, *proxymocks.IsolationProxy, cache.PodCache, trace.Operation) {
+	store := &proxymocks.ImageStore{}
+	ip := &proxymocks.IsolationProxy{}
+	cache := cache.NewVicPodCache()
+	op := trace.NewOperation(context.Background(), "tests")
+
+	return store, ip, cache, op
+}
+
+func fakeError(myErr string) error {
+	return fmt.Errorf("fake error: %s", myErr)
+}
+
+func initPod() {
+	pod = v1.Pod{
+		//TypeMeta: v1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       podName,
+			GenerateName:               "",
+			Namespace:                  "default",
+			SelfLink:                   "/api/v1/namespaces/default/pods/busybox-sleep",
+			UID:                        "b1fc6e1b-499b-11e8-946c-000c29479092",
+			ResourceVersion:            "10338145",
+			Generation:                 0,
+			DeletionTimestamp:          nil,
+			DeletionGracePeriodSeconds: nil,
+			Labels:          map[string]string{},
+			Annotations:     map[string]string{},
+			OwnerReferences: nil,
+			Initializers:    nil,
+			Finalizers:      nil,
+			ClusterName:     "",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "default-token-9q9lr",
+					VolumeSource: v1.VolumeSource{
+						HostPath:             nil,
+						EmptyDir:             nil,
+						GCEPersistentDisk:    nil,
+						AWSElasticBlockStore: nil,
+						GitRepo:              nil,
+						Secret: &v1.SecretVolumeSource{
+							SecretName: "default-token-9q9lr",
+							Items:      nil,
+							Optional:   nil,
+						},
+						NFS:                   nil,
+						ISCSI:                 nil,
+						Glusterfs:             nil,
+						PersistentVolumeClaim: nil,
+						RBD:                  nil,
+						FlexVolume:           nil,
+						Cinder:               nil,
+						CephFS:               nil,
+						Flocker:              nil,
+						DownwardAPI:          nil,
+						FC:                   nil,
+						AzureFile:            nil,
+						ConfigMap:            nil,
+						VsphereVolume:        nil,
+						Quobyte:              nil,
+						AzureDisk:            nil,
+						PhotonPersistentDisk: nil,
+						Projected:            nil,
+						PortworxVolume:       nil,
+						ScaleIO:              nil,
+						StorageOS:            nil,
+					},
+				},
+			},
+			InitContainers: nil,
+			Containers: []v1.Container{
+				{
+					Name:       "busybox-container",
+					Image:      "busybox",
+					Command:    []string{"/bin/sleep"},
+					Args:       []string{"2m"},
+					WorkingDir: "",
+					Ports:      nil,
+					EnvFrom:    nil,
+					Env:        nil,
+					Resources:  v1.ResourceRequirements{},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:             "default-token-9q9lr",
+							ReadOnly:         true,
+							MountPath:        "/var/run/secrets/kubernetes.io/serviceaccount",
+							SubPath:          "",
+							MountPropagation: nil,
+						},
+					},
+					LivenessProbe:            nil,
+					ReadinessProbe:           nil,
+					Lifecycle:                nil,
+					TerminationMessagePath:   "/dev/termination-log",
+					TerminationMessagePolicy: "File",
+					ImagePullPolicy:          "IfNotPresent",
+					SecurityContext:          nil,
+					Stdin:                    false,
+					StdinOnce:                false,
+					TTY:                      false,
+				},
+				{
+					Name:       "alpine-container",
+					Image:      "alpine",
+					Command:    nil,
+					Args:       nil,
+					WorkingDir: "",
+					Ports:      nil,
+					EnvFrom:    nil,
+					Env:        nil,
+					Resources:  v1.ResourceRequirements{},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:             "default-token-9q9lr",
+							ReadOnly:         true,
+							MountPath:        "/var/run/secrets/kubernetes.io/serviceaccount",
+							SubPath:          "",
+							MountPropagation: nil,
+						},
+					},
+					LivenessProbe:            nil,
+					ReadinessProbe:           nil,
+					Lifecycle:                nil,
+					TerminationMessagePath:   "/dev/termination-log",
+					TerminationMessagePolicy: "File",
+					ImagePullPolicy:          "IfNotPresent",
+					SecurityContext:          nil,
+					Stdin:                    false,
+					StdinOnce:                false,
+					TTY:                      false,
+				},
+			},
+			RestartPolicy:                 "Always",
+			TerminationGracePeriodSeconds: new(int64),
+			ActiveDeadlineSeconds:         nil,
+			DNSPolicy:                     "ClusterFirst",
+			NodeSelector:                  map[string]string{"affinity": "vmware"},
+			ServiceAccountName:            "default",
+			DeprecatedServiceAccount:      "default",
+			AutomountServiceAccountToken:  nil,
+			NodeName:                      "vic-kubelet",
+			HostNetwork:                   false,
+			HostPID:                       false,
+			HostIPC:                       false,
+			SecurityContext:               &v1.PodSecurityContext{},
+			ImagePullSecrets:              nil,
+			Hostname:                      "",
+			Subdomain:                     "",
+			Affinity:                      nil,
+			SchedulerName:                 "default-scheduler",
+			Tolerations: []v1.Toleration{
+				{
+					Key:               "node.kubernetes.io/not-ready",
+					Operator:          "Exists",
+					Value:             "",
+					Effect:            "NoExecute",
+					TolerationSeconds: new(int64),
+				},
+				{
+					Key:               "node.kubernetes.io/unreachable",
+					Operator:          "Exists",
+					Value:             "",
+					Effect:            "NoExecute",
+					TolerationSeconds: new(int64),
+				},
+			},
+			HostAliases:       nil,
+			PriorityClassName: "",
+			Priority:          nil,
+		},
+	}
+
+	busyboxIsoConfig = proxy.IsolationContainerConfig{
+		ID:         "",
+		ImageID:    "",
+		LayerID:    "",
+		ImageName:  "busybox",
+		Name:       "busybox-container",
+		Namespace:  "",
+		Cmd:        []string{"/bin/sleep", "2m"},
+		Path:       "",
+		Entrypoint: nil,
+		Env:        nil,
+		WorkingDir: "",
+		User:       "",
+		StopSignal: "",
+		Attach:     false,
+		StdinOnce:  false,
+		OpenStdin:  false,
+		Tty:        false,
+		CPUCount:   2,
+		Memory:     2048,
+		PortMap:    map[string]proxy.PortBinding{},
+	}
+
+	alpineIsoConfig = proxy.IsolationContainerConfig{
+		ID:         "",
+		ImageID:    "",
+		LayerID:    "",
+		ImageName:  "alpine",
+		Name:       "alpine-container",
+		Namespace:  "",
+		Cmd:        nil,
+		Path:       "",
+		Entrypoint: nil,
+		Env:        nil,
+		WorkingDir: "",
+		User:       "",
+		StopSignal: "",
+		Attach:     false,
+		StdinOnce:  false,
+		OpenStdin:  false,
+		Tty:        false,
+		CPUCount:   2,
+		Memory:     2048,
+		PortMap:    map[string]proxy.PortBinding{},
+	}
+
+	vicPod = vicpod.VicPod{
+		ID:  podID,
+		Pod: &pod,
+	}
+}

--- a/providers/vic/operations/pod_creator_test.go
+++ b/providers/vic/operations/pod_creator_test.go
@@ -15,47 +15,16 @@
 package operations
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	vicpod "github.com/virtual-kubelet/virtual-kubelet/providers/vic/pod"
-
 	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 	"github.com/vmware/vic/lib/metadata"
-	"github.com/vmware/vic/pkg/trace"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/cache"
-	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
-	proxymocks "github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy/mocks"
 )
 
-var (
-	pod              v1.Pod
-	imgConfig        metadata.ImageConfig
-	busyboxIsoConfig proxy.IsolationContainerConfig
-	alpineIsoConfig  proxy.IsolationContainerConfig
-	vicPod           vicpod.VicPod
-)
-
-const (
-	podID     = "123"
-	podName   = "busybox-sleep"
-	podHandle = "fakehandle"
-
-	fakeEP = "fake-endpoint"
-)
-
-func createMocks(t *testing.T) (*proxymocks.ImageStore, *proxymocks.IsolationProxy, cache.PodCache, trace.Operation) {
-	store := &proxymocks.ImageStore{}
-	ip := &proxymocks.IsolationProxy{}
-	cache := cache.NewVicPodCache()
-	op := trace.NewOperation(context.Background(), "tests")
-
-	return store, ip, cache, op
+func init() {
+	initPod()
 }
 
 func TestNewPodCreator(t *testing.T) {
@@ -87,14 +56,6 @@ func TestNewPodCreator(t *testing.T) {
 	c, err = NewPodCreator(client, store, proxy, nil, persona, portlayer)
 	assert.Nil(t, c, "Expected nil")
 	assert.Equal(t, err, PodCreatorPodCacheError)
-
-	c, err = NewPodCreator(client, store, proxy, cache, "", portlayer)
-	assert.Nil(t, c, "Expected nil")
-	assert.Equal(t, err, PodCreatorPersonaAddrError)
-
-	c, err = NewPodCreator(client, store, proxy, cache, persona, "")
-	assert.Nil(t, c, "Expected nil")
-	assert.Equal(t, err, PodCreatorPortlayerAddrError)
 }
 
 func TestCreatePod_NilPod(t *testing.T) {
@@ -516,213 +477,4 @@ func TestCreatePod_SetStateError(t *testing.T) {
 	err = c.CreatePod(op, &pod, true)
 	assert.NotNil(t, err, "Expected nil error from createPod")
 	assert.Equal(t, err.Error(), fakeErr.Error())
-}
-
-func init() {
-	pod = v1.Pod{
-		//TypeMeta: v1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:                       "busybox-sleep",
-			GenerateName:               "",
-			Namespace:                  "default",
-			SelfLink:                   "/api/v1/namespaces/default/pods/busybox-sleep",
-			UID:                        "b1fc6e1b-499b-11e8-946c-000c29479092",
-			ResourceVersion:            "10338145",
-			Generation:                 0,
-			DeletionTimestamp:          nil,
-			DeletionGracePeriodSeconds: nil,
-			Labels:          map[string]string{},
-			Annotations:     map[string]string{},
-			OwnerReferences: nil,
-			Initializers:    nil,
-			Finalizers:      nil,
-			ClusterName:     "",
-		},
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{
-				{
-					Name: "default-token-9q9lr",
-					VolumeSource: v1.VolumeSource{
-						HostPath:             nil,
-						EmptyDir:             nil,
-						GCEPersistentDisk:    nil,
-						AWSElasticBlockStore: nil,
-						GitRepo:              nil,
-						Secret: &v1.SecretVolumeSource{
-							SecretName: "default-token-9q9lr",
-							Items:      nil,
-							Optional:   nil,
-						},
-						NFS:                   nil,
-						ISCSI:                 nil,
-						Glusterfs:             nil,
-						PersistentVolumeClaim: nil,
-						RBD:                  nil,
-						FlexVolume:           nil,
-						Cinder:               nil,
-						CephFS:               nil,
-						Flocker:              nil,
-						DownwardAPI:          nil,
-						FC:                   nil,
-						AzureFile:            nil,
-						ConfigMap:            nil,
-						VsphereVolume:        nil,
-						Quobyte:              nil,
-						AzureDisk:            nil,
-						PhotonPersistentDisk: nil,
-						Projected:            nil,
-						PortworxVolume:       nil,
-						ScaleIO:              nil,
-						StorageOS:            nil,
-					},
-				},
-			},
-			InitContainers: nil,
-			Containers: []v1.Container{
-				{
-					Name:       "busybox-container",
-					Image:      "busybox",
-					Command:    []string{"/bin/sleep"},
-					Args:       []string{"2m"},
-					WorkingDir: "",
-					Ports:      nil,
-					EnvFrom:    nil,
-					Env:        nil,
-					Resources:  v1.ResourceRequirements{},
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:             "default-token-9q9lr",
-							ReadOnly:         true,
-							MountPath:        "/var/run/secrets/kubernetes.io/serviceaccount",
-							SubPath:          "",
-							MountPropagation: nil,
-						},
-					},
-					LivenessProbe:            nil,
-					ReadinessProbe:           nil,
-					Lifecycle:                nil,
-					TerminationMessagePath:   "/dev/termination-log",
-					TerminationMessagePolicy: "File",
-					ImagePullPolicy:          "IfNotPresent",
-					SecurityContext:          nil,
-					Stdin:                    false,
-					StdinOnce:                false,
-					TTY:                      false,
-				},
-				{
-					Name:       "alpine-container",
-					Image:      "alpine",
-					Command:    nil,
-					Args:       nil,
-					WorkingDir: "",
-					Ports:      nil,
-					EnvFrom:    nil,
-					Env:        nil,
-					Resources:  v1.ResourceRequirements{},
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:             "default-token-9q9lr",
-							ReadOnly:         true,
-							MountPath:        "/var/run/secrets/kubernetes.io/serviceaccount",
-							SubPath:          "",
-							MountPropagation: nil,
-						},
-					},
-					LivenessProbe:            nil,
-					ReadinessProbe:           nil,
-					Lifecycle:                nil,
-					TerminationMessagePath:   "/dev/termination-log",
-					TerminationMessagePolicy: "File",
-					ImagePullPolicy:          "IfNotPresent",
-					SecurityContext:          nil,
-					Stdin:                    false,
-					StdinOnce:                false,
-					TTY:                      false,
-				},
-			},
-			RestartPolicy:                 "Always",
-			TerminationGracePeriodSeconds: new(int64),
-			ActiveDeadlineSeconds:         nil,
-			DNSPolicy:                     "ClusterFirst",
-			NodeSelector:                  map[string]string{"affinity": "vmware"},
-			ServiceAccountName:            "default",
-			DeprecatedServiceAccount:      "default",
-			AutomountServiceAccountToken:  nil,
-			NodeName:                      "vic-kubelet",
-			HostNetwork:                   false,
-			HostPID:                       false,
-			HostIPC:                       false,
-			SecurityContext:               &v1.PodSecurityContext{},
-			ImagePullSecrets:              nil,
-			Hostname:                      "",
-			Subdomain:                     "",
-			Affinity:                      nil,
-			SchedulerName:                 "default-scheduler",
-			Tolerations: []v1.Toleration{
-				{
-					Key:               "node.kubernetes.io/not-ready",
-					Operator:          "Exists",
-					Value:             "",
-					Effect:            "NoExecute",
-					TolerationSeconds: new(int64),
-				},
-				{
-					Key:               "node.kubernetes.io/unreachable",
-					Operator:          "Exists",
-					Value:             "",
-					Effect:            "NoExecute",
-					TolerationSeconds: new(int64),
-				},
-			},
-			HostAliases:       nil,
-			PriorityClassName: "",
-			Priority:          nil,
-		},
-	}
-
-	busyboxIsoConfig = proxy.IsolationContainerConfig{
-		ID:         "",
-		ImageID:    "",
-		LayerID:    "",
-		ImageName:  "busybox",
-		Name:       "busybox-container",
-		Namespace:  "",
-		Cmd:        []string{"/bin/sleep", "2m"},
-		Path:       "",
-		Entrypoint: nil,
-		Env:        nil,
-		WorkingDir: "",
-		User:       "",
-		StopSignal: "",
-		Attach:     false,
-		StdinOnce:  false,
-		OpenStdin:  false,
-		Tty:        false,
-		CPUCount:   2,
-		Memory:     2048,
-		PortMap:    map[string]proxy.PortBinding{},
-	}
-
-	alpineIsoConfig = proxy.IsolationContainerConfig{
-		ID:         "",
-		ImageID:    "",
-		LayerID:    "",
-		ImageName:  "alpine",
-		Name:       "alpine-container",
-		Namespace:  "",
-		Cmd:        nil,
-		Path:       "",
-		Entrypoint: nil,
-		Env:        nil,
-		WorkingDir: "",
-		User:       "",
-		StopSignal: "",
-		Attach:     false,
-		StdinOnce:  false,
-		OpenStdin:  false,
-		Tty:        false,
-		CPUCount:   2,
-		Memory:     2048,
-		PortMap:    map[string]proxy.PortBinding{},
-	}
 }

--- a/providers/vic/operations/pod_deleter_test.go
+++ b/providers/vic/operations/pod_deleter_test.go
@@ -1,0 +1,226 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+)
+
+func init() {
+	initPod()
+}
+
+func TestNewPodDeleter(t *testing.T) {
+	_, ip, cache, _ := createMocks(t)
+	client := client.Default
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	// Positive Cases
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+
+	// Negative Cases
+	d, err = NewPodDeleter(nil, ip, cache, persona, portlayer)
+	assert.Nil(t, d, "Expected nil")
+	assert.Equal(t, err, PodDeleterPortlayerClientError)
+
+	d, err = NewPodDeleter(client, nil, cache, persona, portlayer)
+	assert.Nil(t, d, "Expected nil")
+	assert.Equal(t, err, PodDeleterIsolationProxyError)
+
+	d, err = NewPodDeleter(client, ip, nil, persona, portlayer)
+	assert.Nil(t, d, "Expected nil")
+	assert.Equal(t, err, PodDeleterPodCacheError)
+}
+
+func TestDeletePod(t *testing.T) {
+	client := client.Default
+	_, ip, cache, op := createMocks(t)
+
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+	ip.On("Remove", op, podID, true).Return(nil)
+
+	// Add vicPod to the cache
+	cache.Add(op, "", pod.Name, &vicPod)
+
+	// Positive case
+	err = d.DeletePod(op, &pod)
+	assert.Nil(t, err, "Expected nil")
+}
+
+func TestDeletePodErrorHandle(t *testing.T) {
+	client := client.Default
+	_, ip, cache, op := createMocks(t)
+
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+	ip.On("Remove", op, podID, true).Return(nil)
+
+	// Add vicPod to the cache
+	cache.Add(op, "", pod.Name, &vicPod)
+
+	// Failed Handle
+	fakeErr := fakeError("invalid handle")
+	ip.On("Handle", op, podID, podName).Return("", fakeErr)
+
+	err = d.DeletePod(op, &pod)
+	assert.Equal(t, err, fakeErr, "Expected invalid handle error")
+}
+
+func TestDeletePodErrorUnbindScope(t *testing.T) {
+	client := client.Default
+	_, ip, cache, op := createMocks(t)
+
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+	ip.On("Remove", op, podID, true).Return(nil)
+
+	// Add vicPod to the cache
+	cache.Add(op, "", pod.Name, &vicPod)
+	// Failed UnbindScope
+	fakeErr := fakeError("failed UnbindScope")
+	ip.On("UnbindScope", op, podHandle, podName).Return("", nil, fakeErr)
+
+	err = d.DeletePod(op, &pod)
+	assert.Equal(t, err, fakeErr, "Expected failed UnbindScope error")
+}
+
+func TestDeletePodErrorSetState(t *testing.T) {
+	client := client.Default
+	_, ip, cache, op := createMocks(t)
+
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+	ip.On("Remove", op, podID, true).Return(nil)
+
+	// Add vicPod to the cache
+	cache.Add(op, "", pod.Name, &vicPod)
+
+	// Failed SetState
+	fakeErr := fakeError("failed SetState")
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return("", fakeErr)
+	err = d.DeletePod(op, &pod)
+	assert.Equal(t, err, fakeErr, "Expected failed SetState error")
+}
+
+func TestDeletePodErrorCommitHandle(t *testing.T) {
+	client := client.Default
+	_, ip, cache, op := createMocks(t)
+
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("Remove", op, podID, true).Return(nil)
+
+	// Add vicPod to the cache
+	cache.Add(op, "", pod.Name, &vicPod)
+	// Failed Commit
+	fakeErr := fakeError("failed Commit")
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(fakeErr)
+	err = d.DeletePod(op, &pod)
+	assert.Equal(t, err, fakeErr, "Expected failed Commit error")
+}
+
+func TestDeletePodErrorRemove(t *testing.T) {
+	client := client.Default
+	_, ip, cache, op := createMocks(t)
+
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+
+	// Add vicPod to the cache
+	cache.Add(op, "", pod.Name, &vicPod)
+
+	// Failed Remove
+	fakeErr := fakeError("failed Remove")
+	ip.On("Remove", op, podID, true).Return(fakeErr)
+	err = d.DeletePod(op, &pod)
+	assert.Equal(t, err, fakeErr, "Expected failed Remove error")
+}
+
+func TestDeletePodErrorBadArgs(t *testing.T) {
+	client := client.Default
+	_, ip, cache, op := createMocks(t)
+	persona := "1.2.3.4"
+	portlayer := "1.2.3.4"
+
+	d, err := NewPodDeleter(client, ip, cache, persona, portlayer)
+	assert.NotNil(t, d, "Expected non-nil creating a pod Deleter but received nil")
+
+	// Negative Cases
+	err = d.DeletePod(op, nil)
+	assert.Equal(t, err, PodDeleterInvalidPodSpecError)
+}

--- a/providers/vic/operations/pod_starter.go
+++ b/providers/vic/operations/pod_starter.go
@@ -45,7 +45,7 @@ const (
 	PodStarterInvalidPodNameError  = VicPodStarterError("PodStarter called with invalid Pod name")
 )
 
-func NewPodStarter(client *client.PortLayer, isolationProxy proxy.IsolationProxy) (*VicPodStarter, error) {
+func NewPodStarter(client *client.PortLayer, isolationProxy proxy.IsolationProxy) (PodStarter, error) {
 	defer trace.End(trace.Begin("", context.Background()))
 
 	if client == nil {
@@ -71,15 +71,6 @@ func NewPodStarter(client *client.PortLayer, isolationProxy proxy.IsolationProxy
 //		error
 func (v *VicPodStarter) Start(op trace.Operation, id, name string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("id(%s), name(%s)", id, name), op))
-
-	if id == "" {
-		op.Errorf(PodStarterInvalidPodIDError.Error())
-		return PodStarterInvalidPodIDError
-	}
-	if name == "" {
-		op.Errorf(PodStarterInvalidPodNameError.Error())
-		return PodStarterInvalidPodNameError
-	}
 
 	h, err := v.isolationProxy.Handle(op, id, name)
 	if err != nil {

--- a/providers/vic/operations/pod_starter_test.go
+++ b/providers/vic/operations/pod_starter_test.go
@@ -15,15 +15,12 @@
 package operations
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware/vic/lib/apiservers/portlayer/client"
-	"github.com/vmware/vic/pkg/trace"
-
 	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy/mocks"
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
 )
 
 func TestNewPodStarter(t *testing.T) {
@@ -47,21 +44,4 @@ func TestNewPodStarter(t *testing.T) {
 	assert.Equal(t, err, PodStarterIsolationProxyError)
 }
 
-func TestStartPod_BadArgs(t *testing.T) {
-	client := client.Default
-	ip := &mocks.IsolationProxy{}
-	op := trace.NewOperation(context.Background(), "")
-
-	// Start with arguments
-	s, err := NewPodStarter(client, ip)
-	assert.NotNil(t, s, "Expected non-nil creating a pod starter but received nil")
-
-	// Negative Cases
-	err = s.Start(op, "", podName)
-	assert.Equal(t, err, PodStarterInvalidPodIDError)
-
-	err = s.Start(op, podID, "")
-	assert.Equal(t, err, PodStarterInvalidPodNameError)
-}
-
-//NOTE: The rest of PodStarter tests were handled in PocCreator's tests so there's no need for further tests.
+//NOTE: The rest of PodStarter tests were handled in PodCreator's tests so there's no need for further tests.

--- a/providers/vic/operations/pod_stopper.go
+++ b/providers/vic/operations/pod_stopper.go
@@ -27,7 +27,7 @@ import (
 )
 
 type PodStopper interface {
-	Start(op trace.Operation, id, name string) error
+	Stop(op trace.Operation, id, name string) error
 }
 
 type VicPodStopper struct {
@@ -42,11 +42,11 @@ func (e VicPodStopperError) Error() string { return string(e) }
 const (
 	PodStopperPortlayerClientError = VicPodStopperError("PodStopper called with an invalid portlayer client")
 	PodStopperIsolationProxyError  = VicPodStopperError("PodStopper called with an invalid isolation proxy")
-	PodStopperEmptyPodIDError   = VicPodStopperError("PodStopper called with empty username")
-	PodStopperEmptyPodNameError   = VicPodStopperError("PodStopper called with empty password")
+	PodStopperInvalidPodIDError    = VicPodStopperError("PodStopper called with invalid PodID")
+	PodStopperInvalidPodNameError  = VicPodStopperError("PodStopper called with invalid PodName")
 )
 
-func NewPodStopper(client *client.PortLayer, isolationProxy proxy.IsolationProxy) (*VicPodStopper, error) {
+func NewPodStopper(client *client.PortLayer, isolationProxy proxy.IsolationProxy) (PodStopper, error) {
 	if client == nil {
 		return nil, PodStopperPortlayerClientError
 	} else if isolationProxy == nil {
@@ -69,12 +69,6 @@ func NewPodStopper(client *client.PortLayer, isolationProxy proxy.IsolationProxy
 // 		error
 func (v *VicPodStopper) Stop(op trace.Operation, id, name string) error {
 	defer trace.End(trace.Begin(fmt.Sprintf("id(%s), name(%s)", id, name), op))
-
-	if id == "" {
-		return PodStopperEmptyPodIDError
-	} else if name == "" {
-		return PodStopperEmptyPodNameError
-	}
 
 	operation := func() error {
 		return v.stop(op, id, name)

--- a/providers/vic/operations/pod_stopper_test.go
+++ b/providers/vic/operations/pod_stopper_test.go
@@ -1,0 +1,147 @@
+// Copyright 2018 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+)
+
+func TestNewPodStopper(t *testing.T) {
+	_, ip, _, _ := createMocks(t)
+	client := client.Default
+
+	// Positive Cases
+	s, err := NewPodStopper(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Stopper but received nil")
+
+	// Negative Cases
+	s, err = NewPodStopper(nil, ip)
+	assert.Nil(t, s, "Expected nil")
+	assert.Equal(t, err, PodStopperPortlayerClientError)
+
+	s, err = NewPodStopper(client, nil)
+	assert.Nil(t, s, "Expected nil")
+	assert.Equal(t, err, PodStopperIsolationProxyError)
+}
+
+func TestStopPod(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	// Start with arguments
+	s, err := NewPodStopper(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Stopper but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+
+	// Positive case
+	err = s.Stop(op, podID, podName)
+	assert.Nil(t, err, "Expected nil")
+}
+
+func TestStopPodErrorHandle(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	// Start with arguments
+	s, err := NewPodStopper(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Stopper but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+
+	// Failed Handle
+	fakeErr := fakeError("invalid handle")
+	ip.On("Handle", op, podID, podName).Return("", fakeErr)
+
+	err = s.Stop(op, podID, podName)
+	assert.Equal(t, err, fakeErr, "Expected invalid handle error")
+}
+
+func TestStopPodErrorUnbindScope(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	// Start with arguments
+	s, err := NewPodStopper(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Stopper but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+
+	// Failed UnbindScope
+	fakeErr := fakeError("failed UnbindScope")
+	ip.On("UnbindScope", op, podHandle, podName).Return("", nil, fakeErr)
+
+	err = s.Stop(op, podID, podName)
+	assert.Equal(t, err, fakeErr, "Expected failed UnbindScope error")
+}
+
+func TestStopPodErrorSetState(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	// Start with arguments
+	s, err := NewPodStopper(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Stopper but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(nil)
+
+	// Failed SetState
+	fakeErr := fakeError("failed SetState")
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return("", fakeErr)
+	err = s.Stop(op, podID, podName)
+	assert.Equal(t, err, fakeErr, "Expected failed SetState error")
+}
+
+func TestStopPodErrorCommit(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	// Start with arguments
+	s, err := NewPodStopper(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Stopper but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	ip.On("Handle", op, podID, podName).Return(podHandle, nil)
+	ip.On("UnbindScope", op, podHandle, podName).Return(podHandle, fakeEP, nil)
+	ip.On("SetState", op, podHandle, podName, "STOPPED").Return(podHandle, nil)
+
+	// Failed Commit
+	fakeErr := fakeError("failed Commit")
+	ip.On("CommitHandle", op, podHandle, podID, int32(-1)).Return(fakeErr)
+	err = s.Stop(op, podID, podName)
+	assert.Equal(t, err, fakeErr ,"Expected failed Commit error")
+}


### PR DESCRIPTION
This PR contains the implementation of the unit test for the Vic Provider Operations of Stop and Delete.  The PR also includes some re-factoring of the other Vic Provider Operations:
- return the interface instead of the implementation when constructing the object
- remove tests for empty strings

The PR also backs out a fix in the Makefile.