### PR TITLE
Report proper IP address for node and pods

### DIFF
--- a/providers/vic/operations/common_test.go
+++ b/providers/vic/operations/common_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"fmt"
+
 	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/cache"
 	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
 	proxymocks "github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy/mocks"
@@ -30,7 +31,10 @@ const (
 	podName   = "busybox-sleep"
 	podHandle = "fakehandle"
 
-	fakeEP = "fake-endpoint"
+	fakeEP        = "fake-endpoint"
+	stateRunning  = "Running"
+	stateStarting = "Starting"
+	stateError    = "error"
 )
 
 func createMocks(t *testing.T) (*proxymocks.ImageStore, *proxymocks.IsolationProxy, cache.PodCache, trace.Operation) {

--- a/providers/vic/operations/pod_creator.go
+++ b/providers/vic/operations/pod_creator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kr/pretty"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/vmware/vic/pkg/trace"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PodCreator interface {
@@ -143,6 +145,8 @@ func (v *VicPodCreator) CreatePod(op trace.Operation, pod *v1.Pod, start bool) e
 		if err != nil {
 			return err
 		}
+		now := metav1.NewTime(time.Now())
+		vp.Pod.Status.StartTime = &now
 	}
 
 	return nil

--- a/providers/vic/operations/pod_status.go
+++ b/providers/vic/operations/pod_status.go
@@ -1,0 +1,145 @@
+package operations
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/pkg/trace"
+
+	"k8s.io/api/core/v1"
+)
+
+type PodStatus interface {
+	GetStatus(op trace.Operation, namespace string, name string) (*v1.PodStatus, error)
+}
+
+type VicPodStatus struct {
+	client         *client.PortLayer
+	isolationProxy proxy.IsolationProxy
+}
+
+type VicPodStatusError string
+
+func (e VicPodStatusError) Error() string { return string(e) }
+
+const (
+	PodStatusPortlayerClientError = VicPodStatusError("PodStatus called with an invalid portlayer client")
+	PodStatusIsolationProxyError  = VicPodStatusError("PodStatus called with an invalid isolation proxy")
+	PodStatusInvalidPodIDError    = VicPodStatusError("PodStatus called with invalid PodID")
+	PodStatusInvalidPodNameError  = VicPodStatusError("PodStatus called with invalid PodName")
+)
+
+func NewPodStatus(client *client.PortLayer, isolationProxy proxy.IsolationProxy) (PodStatus, error) {
+	if client == nil {
+		return nil, PodStatusPortlayerClientError
+	} else if isolationProxy == nil {
+		return nil, PodStatusIsolationProxyError
+	}
+
+	return &VicPodStatus{
+		client:         client,
+		isolationProxy: isolationProxy,
+	}, nil
+}
+
+// Gets pod status does not delete it
+//
+// arguments:
+//		op		operation trace logger
+//		id		pod id
+//		name	pod name
+// returns:
+// 		error
+func (v *VicPodStatus) GetStatus(op trace.Operation, id, name string) (*v1.PodStatus, error) {
+	defer trace.End(trace.Begin(fmt.Sprintf("id(%s), name(%s)", id, name), op))
+
+	return v.getStatus(op, id, name)
+}
+
+func (v *VicPodStatus) getStatus(op trace.Operation, id, name string) (*v1.PodStatus, error) {
+	defer trace.End(trace.Begin(fmt.Sprintf("id(%s), name(%s)", id, name), op))
+
+	// Get current state
+	state, err := v.isolationProxy.State(op, id, name)
+	var phase v1.PodPhase
+	podInitialized := v1.ConditionTrue
+	podReady := v1.ConditionTrue
+	podScheduled := v1.ConditionTrue
+
+	if err != nil {
+		phase = v1.PodUnknown
+		podReady = v1.ConditionUnknown
+		podInitialized = v1.ConditionUnknown
+		podScheduled = v1.ConditionUnknown
+	} else {
+		switch state {
+		case "Error":
+			// force stop if container state is error to make sure container is deletable later
+			phase = v1.PodFailed
+			podReady = v1.ConditionFalse
+		case "Starting":
+			// if we are starting let the user know they must use the force
+			phase = v1.PodPending
+			podInitialized = v1.ConditionFalse
+			podReady = v1.ConditionFalse
+		case "Stopped":
+			phase = v1.PodSucceeded
+			podReady = v1.ConditionFalse
+			podInitialized = v1.ConditionFalse
+		case "Running":
+			phase = v1.PodRunning
+		}
+	}
+
+	status := &v1.PodStatus{
+		Phase: phase,
+		Conditions: []v1.PodCondition{
+			{
+				Type:   v1.PodInitialized,
+				Status: podInitialized,
+			},
+			{
+				Type:   v1.PodReady,
+				Status: podReady,
+			},
+			{
+				Type:   v1.PodScheduled,
+				Status: podScheduled,
+			},
+		},
+	}
+	addresses, err := v.getIPAddresses(op, id, name)
+	if err == nil && len(addresses) > 0 {
+		status.HostIP = addresses[0]
+		status.PodIP = addresses[0]
+	} else {
+		status.HostIP = "0.0.0.0"
+		status.PodIP = "0.0.0.0"
+	}
+
+	return status, nil
+}
+
+func (v *VicPodStatus) getIPAddresses(op trace.Operation, id, name string) ([]string, error) {
+	defer trace.End(trace.Begin(id, op))
+
+	endpointConfigs, err := v.isolationProxy.NetworkConfigs(op, id, name)
+	if err != nil {
+		return nil, err
+	}
+
+	IPAddresses := make([]string, 0)
+	for _, ep := range endpointConfigs {
+		if ep.Address != "" {
+			ip, _, err := net.ParseCIDR(ep.Address)
+			if err == nil {
+				IPAddresses = append(IPAddresses, ip.String())
+			}
+		}
+	}
+
+	return IPAddresses, err
+}

--- a/providers/vic/operations/pod_status_test.go
+++ b/providers/vic/operations/pod_status_test.go
@@ -1,0 +1,143 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/vic/lib/apiservers/portlayer/client"
+	"github.com/vmware/vic/lib/apiservers/portlayer/models"
+	"k8s.io/api/core/v1"
+)
+
+func TestNewPodStatus(t *testing.T) {
+	_, ip, _, _ := createMocks(t)
+	client := client.Default
+
+	// Positive Cases
+	s, err := NewPodStatus(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Status but received nil")
+
+	// Negative Cases
+	s, err = NewPodStatus(nil, ip)
+	assert.Nil(t, s, "Expected nil")
+	assert.Equal(t, err, PodStatusPortlayerClientError)
+
+	s, err = NewPodStatus(client, nil)
+	assert.Nil(t, s, "Expected nil")
+	assert.Equal(t, err, PodStatusIsolationProxyError)
+}
+
+func TestStatusPodStarting(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	s, err := NewPodStatus(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Status but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	Endpoints := []*models.EndpointConfig {
+		{ Address: "1.2.3.4/24" },
+	}
+
+	// Set up the mocks for this test
+	ip.On("State", op, podID, podName).Return(stateStarting, nil)
+	ip.On("NetworkConfigs", op, podID, podName).Return(Endpoints, nil)
+
+	// Positive case
+	status, err := s.GetStatus(op, podID, podName)
+	assert.Nil(t, err, "Expected nil")
+	assert.Equal(t, status.Phase, v1.PodPending, "Expected Phase Pending")
+	verifyConditions(t, status.Conditions, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse)
+	assert.Equal(t, status.HostIP, "1.2.3.4", "Expected Host IP Address")
+	assert.Equal(t, status.PodIP, "1.2.3.4", "Expected Pod IP Address")
+}
+
+func TestStatusPodRunning(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	s, err := NewPodStatus(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Status but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	Endpoints := []*models.EndpointConfig {
+		{ Address: "1.2.3.4/24" },
+	}
+
+	// Set up the mocks for this test
+	ip.On("State", op, podID, podName).Return(stateRunning, nil)
+	ip.On("NetworkConfigs", op, podID, podName).Return(Endpoints, nil)
+
+	// Pod Running case
+	status, err := s.GetStatus(op, podID, podName)
+	assert.Nil(t, err, "Expected nil")
+	assert.Equal(t, status.Phase, v1.PodRunning, "Expected Phase PodRunning")
+	verifyConditions(t, status.Conditions, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue)
+	assert.Equal(t, status.HostIP, "1.2.3.4", "Expected Host IP Address")
+	assert.Equal(t, status.PodIP, "1.2.3.4", "Expected Pod IP Address")
+}
+
+func TestStatusPodError(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	s, err := NewPodStatus(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Status but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	Endpoints := []*models.EndpointConfig {
+		{ Address: "1.2.3.4/24" },
+	}
+
+	// Set up the mocks for this test
+	ip.On("State", op, podID, podName).Return(stateError, nil)
+	ip.On("NetworkConfigs", op, podID, podName).Return(Endpoints, nil)
+
+	// Pod error case
+	status, err := s.GetStatus(op, podID, podName)
+
+	assert.Equal(t, status.Phase, v1.PodFailed, "Expected Phase PodFailed")
+	verifyConditions(t, status.Conditions, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse)
+	assert.Equal(t, status.HostIP, "1.2.3.4", "Expected Host IP Address")
+	assert.Equal(t, status.PodIP, "1.2.3.4", "Expected Pod IP Address")
+}
+
+func TestStatusError(t *testing.T) {
+	client := client.Default
+	_, ip, _, op := createMocks(t)
+
+	// Start with arguments
+	s, err := NewPodStatus(client, ip)
+	assert.NotNil(t, s, "Expected non-nil creating a pod Status but received nil")
+	assert.Nil(t, err, "Expected nil")
+
+	// Set up the mocks for this test
+	fakeErr := fakeError("invalid Pod")
+	ip.On("State", op, podID, podName).Return("", fakeErr)
+	ip.On("NetworkConfigs", op, podID, podName).Return(nil, fakeErr)
+
+	// Error case
+	status, err := s.GetStatus(op, podID, podName)
+	assert.Nil(t, err, "Expected nil")
+	assert.Equal(t, status.Phase, v1.PodUnknown, "Expected Phase PodUnknown")
+	verifyConditions(t, status.Conditions, v1.ConditionUnknown, v1.ConditionUnknown, v1.ConditionUnknown)
+	assert.Equal(t, status.HostIP, "0.0.0.0", "Expected Host IP Address")
+	assert.Equal(t, status.PodIP, "0.0.0.0", "Expected Pod IP Address")
+}
+
+func verifyConditions(t *testing.T, conditions []v1.PodCondition, scheduled v1.ConditionStatus, initialized v1.ConditionStatus, ready v1.ConditionStatus) {
+	for _, condition := range conditions {
+		switch condition.Type {
+		case v1.PodScheduled:
+			assert.Equal(t, condition.Status, scheduled, "Condition Pod Scheduled")
+			break
+		case v1.PodInitialized:
+			assert.Equal(t, condition.Status, initialized, "Condition Pod Initialized")
+			break
+		case v1.PodReady:
+			assert.Equal(t, condition.Status, ready, "Condition Pod Ready")
+			break
+		}
+	}
+}

--- a/providers/vic/proxy/mocks/IsolationProxy.go
+++ b/providers/vic/proxy/mocks/IsolationProxy.go
@@ -2,6 +2,7 @@
 package mocks
 
 import mock "github.com/stretchr/testify/mock"
+import models "github.com/vmware/vic/lib/apiservers/portlayer/models"
 import proxy "github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
 import trace "github.com/vmware/vic/pkg/trace"
 
@@ -196,6 +197,52 @@ func (_m *IsolationProxy) Handle(op trace.Operation, id string, name string) (st
 		r0 = rf(op, id, name)
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(trace.Operation, string, string) error); ok {
+		r1 = rf(op, id, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// NetworkConfigs provides a mock function with given fields: op, id, name
+func (_m *IsolationProxy) NetworkConfigs(op trace.Operation, id string, name string) ([]*models.EndpointConfig, error) {
+	ret := _m.Called(op, id, name)
+
+	var r0 []*models.EndpointConfig
+	if rf, ok := ret.Get(0).(func(trace.Operation, string, string) []*models.EndpointConfig); ok {
+		r0 = rf(op, id, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*models.EndpointConfig)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(trace.Operation, string, string) error); ok {
+		r1 = rf(op, id, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PodConfig provides a mock function with given fields: op, id, name
+func (_m *IsolationProxy) PodConfig(op trace.Operation, id string, name string) (*models.ContainerConfig, error) {
+	ret := _m.Called(op, id, name)
+
+	var r0 *models.ContainerConfig
+	if rf, ok := ret.Get(0).(func(trace.Operation, string, string) *models.ContainerConfig); ok {
+		r0 = rf(op, id, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.ContainerConfig)
+		}
 	}
 
 	var r1 error

--- a/providers/vic/vic_provider.go
+++ b/providers/vic/vic_provider.go
@@ -28,6 +28,8 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/proxy"
 	"github.com/virtual-kubelet/virtual-kubelet/providers/vic/utils"
 
+	"net"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,6 +122,7 @@ func waitForVCH(op trace.Operation, plClient *client.PortLayer, personaAddr stri
 	backoffConf := retry.NewBackoffConfig()
 	backoffConf.MaxInterval = 2 * time.Second
 	backoffConf.InitialInterval = 500 * time.Millisecond
+	backoffConf.MaxElapsedTime = 10 * time.Minute
 
 	// Wait for portlayer to start up
 	systemProxy := vicproxy.NewSystemProxy(plClient)
@@ -262,34 +265,49 @@ func (v *VicProvider) GetPodStatus(namespace, name string) (*v1.PodStatus, error
 	defer trace.End(trace.Begin("GetPodStatus", op))
 
 	now := metav1.NewTime(time.Now())
-
-	status := &v1.PodStatus{
-		Phase:     v1.PodRunning,
-		HostIP:    "1.2.3.4",
-		PodIP:     "5.6.7.8",
+	errorStatus := &v1.PodStatus{
+		Phase:     v1.PodUnknown,
 		StartTime: &now,
 		Conditions: []v1.PodCondition{
 			{
 				Type:   v1.PodInitialized,
-				Status: v1.ConditionTrue,
+				Status: v1.ConditionUnknown,
 			},
 			{
 				Type:   v1.PodReady,
-				Status: v1.ConditionTrue,
+				Status: v1.ConditionUnknown,
 			},
 			{
 				Type:   v1.PodScheduled,
-				Status: v1.ConditionTrue,
+				Status: v1.ConditionUnknown,
 			},
 		},
 	}
 
-	pod, err := v.GetPod(namespace, name)
+	// Look for the pod in our cache of running pods
+	vp, err := v.podCache.Get(op, namespace, name)
 	if err != nil {
-		return status, err
+		return errorStatus, err
 	}
 
-	for _, container := range pod.Spec.Containers {
+	// Instantiate status object
+	statusReporter, err := operations.NewPodStatus(v.client, v.isolationProxy)
+	if err != nil {
+		return errorStatus, err
+	}
+
+	status, err := statusReporter.GetStatus(op, vp.ID, name)
+	if err != nil {
+		return errorStatus, err
+	}
+
+	if vp.Pod.Status.StartTime != nil {
+		status.StartTime = vp.Pod.Status.StartTime
+	} else {
+		status.StartTime = &now
+	}
+
+	for _, container := range vp.Pod.Spec.Containers {
 		status.ContainerStatuses = append(status.ContainerStatuses, v1.ContainerStatus{
 			Name:         container.Name,
 			Image:        container.Image,
@@ -297,7 +315,7 @@ func (v *VicProvider) GetPodStatus(namespace, name string) (*v1.PodStatus, error
 			RestartCount: 0,
 			State: v1.ContainerState{
 				Running: &v1.ContainerStateRunning{
-					StartedAt: now,
+					StartedAt: *status.StartTime,
 				},
 			},
 		})
@@ -390,7 +408,25 @@ func (v *VicProvider) NodeConditions() []v1.NodeCondition {
 // NodeAddresses returns a list of addresses for the node status
 // within Kubernetes.
 func (v *VicProvider) NodeAddresses() []v1.NodeAddress {
-	return nil
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return []v1.NodeAddress{}
+	}
+
+	var outAddresses []v1.NodeAddress
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() || ipnet.IP.To4() == nil {
+			continue
+		}
+		outAddress := v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: ipnet.IP.String(),
+		}
+		outAddresses = append(outAddresses, outAddress)
+	}
+
+	return outAddresses
 }
 
 // NodeDaemonEndpoints returns NodeDaemonEndpoints for the node status


### PR DESCRIPTION
This PR contains the following changes:
- Report the correct IP addresses where the virtual kubelet is running (kubectl describe node)
- Report the correct IP address of pods (kubectl describe pod)
- Fix start time in Pod descriptor